### PR TITLE
use Concat instead of Format when simple

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -12,7 +12,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(conversion.ConversionKind == ConversionKind.InterpolatedString);
             BoundExpression format;
             ArrayBuilder<BoundExpression> expressions;
-            MakeInterpolatedStringFormat((BoundInterpolatedString)conversion.Operand, out format, out expressions);
+            ArrayBuilder<BoundExpression> concatExpressions;
+            MakeInterpolatedStringFormat((BoundInterpolatedString)conversion.Operand, out format, out expressions, out concatExpressions);
             expressions.Insert(0, format);
             var stringFactory = _factory.WellKnownType(WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory);
 
@@ -32,13 +33,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        private void MakeInterpolatedStringFormat(BoundInterpolatedString node, out BoundExpression format, out ArrayBuilder<BoundExpression> expressions)
+        private bool MakeInterpolatedStringFormat(BoundInterpolatedString node, out BoundExpression format, out ArrayBuilder<BoundExpression> expressions, out ArrayBuilder<BoundExpression> concatExpressions)
         {
             _factory.Syntax = node.Syntax;
             int n = node.Parts.Length - 1;
             var formatString = PooledStringBuilder.GetInstance();
             expressions = ArrayBuilder<BoundExpression>.GetInstance(n + 1);
+            concatExpressions = ArrayBuilder<BoundExpression>.GetInstance(n + 1);
             int nextFormatPosition = 0;
+            bool isSimpleConcatString = true;
             for (int i = 0; i <= n; i++)
             {
                 var part = node.Parts[i];
@@ -47,6 +50,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // this is one of the literal parts
                     formatString.Builder.Append(part.ConstantValue.StringValue);
+                    
+                    // no point in continuing to unescape when the result will be unused
+                    if (isSimpleConcatString) 
+                    {
+                        part = HandleEscapeSequences(part);
+                    }
                 }
                 else
                 {
@@ -55,69 +64,97 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (fillin.Alignment != null && !fillin.Alignment.HasErrors)
                     {
                         formatString.Builder.Append(",").Append(fillin.Alignment.ConstantValue.Int64Value);
+                        isSimpleConcatString = false;
                     }
                     if (fillin.Format != null && !fillin.Format.HasErrors)
                     {
                         formatString.Builder.Append(":").Append(fillin.Format.ConstantValue.StringValue);
+                        isSimpleConcatString = false;
                     }
                     formatString.Builder.Append("}");
-                    var value = fillin.Value;
-                    if (value.Type?.TypeKind == TypeKind.Dynamic)
+                    part = fillin.Value;
+                    if (part.Type?.TypeKind == TypeKind.Dynamic)
                     {
-                        value = MakeConversion(value, _compilation.ObjectType, @checked: false);
+                        part = MakeConversion(part, _compilation.ObjectType, @checked: false);
                     }
 
-                    expressions.Add(value); // NOTE: must still be lowered
+                    expressions.Add(part); // NOTE: must still be lowered
                 }
+                concatExpressions.Add(part); // NOTE: must still be lowered
             }
 
             format = _factory.StringLiteral(formatString.ToStringAndFree());
+            return isSimpleConcatString;
+        }
+
+        private BoundLiteral HandleEscapeSequences(BoundExpression input) 
+        {
+            // There are no fill-ins. Handle the escaping of {{ and }} and return the value.
+            Debug.Assert(!input.HasErrors && input.ConstantValue != null && input.ConstantValue.IsString);
+            var builder = PooledStringBuilder.GetInstance();
+            var formatText = input.ConstantValue.StringValue;
+            int formatLength = formatText.Length;
+            for (int i = 0; i < formatLength; i++)
+            {
+                char c = formatText[i];
+                builder.Builder.Append(c);
+                if ((c == '{' || c == '}') && (i + 1) < formatLength && formatText[i + 1] == c)
+                {
+                    i++;
+                }
+            }
+            return _factory.StringLiteral(builder.ToStringAndFree());
         }
 
         public override BoundNode VisitInterpolatedString(BoundInterpolatedString node)
         {
             //
-            // We lower an interpolated string into an invocation of String.Format.  For example, we translate the expression
+            // We lower an interpolated string into an invocation of String.Format or string concatenation, depending on 
+            // the existence of string format instructions. Some examples:
             //
-            //     $"Jenny don\'t change your number { 8675309 }"
+            //     $"Braces {{ }}"
+            //     $"#{a}-{b}"
+            //     $"Jenny don\'t change your number { 8675309 :#-0000}"
             //
             // into
             //
-            //     String.Format("Jenny don\'t change your number {0}", new object[] { 8675309 })
+            //     "Braces { }"
+            //     "#" + a + "-" + b
+            //     String.Format("Jenny don\'t change your number {0:#-0000}", new object[] { 8675309 })
             //
 
             Debug.Assert(node.Type.SpecialType == SpecialType.System_String); // if target-converted, we should not get here.
             BoundExpression format;
             ArrayBuilder<BoundExpression> expressions;
-            MakeInterpolatedStringFormat(node, out format, out expressions);
-            if (expressions.Count == 0)
+            ArrayBuilder<BoundExpression> concatExpressions;
+            bool isSimpleConcatString = MakeInterpolatedStringFormat(node, out format, out expressions, out concatExpressions);
+            if (expressions.Count == 0) 
             {
-                // There are no fill-ins. Handle the escaping of {{ and }} and return the value.
-                Debug.Assert(!format.HasErrors && format.ConstantValue != null && format.ConstantValue.IsString);
-                var builder = PooledStringBuilder.GetInstance();
-                var formatText = format.ConstantValue.StringValue;
-                int formatLength = formatText.Length;
-                for (int i = 0; i < formatLength; i++)
-                {
-                    char c = formatText[i];
-                    builder.Builder.Append(c);
-                    if ((c == '{' || c == '}') && (i + 1) < formatLength && formatText[i + 1] == c)
-                    {
-                        i++;
-                    }
-                }
-                return _factory.StringLiteral(builder.ToStringAndFree());
+                return HandleEscapeSequences(format);
             }
 
+            var stringType = node.Type;
+            BoundExpression result;
             // The normal pattern for lowering is to lower subtrees before the enclosing tree. However we cannot lower
             // the arguments first in this situation because we do not know what conversions will be
             // produced for the arguments until after we've done overload resolution. So we produce the invocation
             // and then lower it along with its arguments.
-            expressions.Insert(0, format);
-            var stringType = node.Type;
-            var result = _factory.StaticCall(stringType, "Format", expressions.ToImmutableAndFree(),
-                allowUnexpandedForm: false // if an interpolation expression is the null literal, it should not match a params parameter.
-                );
+            if (isSimpleConcatString) 
+            {
+                result = _factory.StaticCall(stringType, "Concat", concatExpressions.ToImmutableAndFree(),
+                    allowUnexpandedForm: false
+                    );
+
+            } 
+            else 
+            {
+                expressions.Insert(0, format);
+                result = _factory.StaticCall(stringType, "Format", expressions.ToImmutableAndFree(),
+                    allowUnexpandedForm: false
+                    // if an interpolation expression is the null literal, it should not match a params parameter.
+                    );
+
+            }
             if (!result.HasAnyErrors)
             {
                 result = VisitExpression(result); // lower the arguments AND handle expanded form, argument conversions, etc.


### PR DESCRIPTION
If there are no format string *alignment* or *formatString* parameters, it should be faster to do a `string.Concat` call instead of `string.Format`.

Fixes #6669

Tests coming eventually, I cannot install 2015 Update 1 RC on this machine and am affected by both #4387 and #5876 and have a bunch of unit test failures within Resharper and when running tests from the cli...